### PR TITLE
Add pids-limit patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This builds an Amazon ECS Container Agent, with some patches applied for Remind'
 ## Patches
 
 1. [1-tty](./patches/1-tty): This patch provides a method to pass down the `-t` (allocate TTY) and `-i` (open stdin) flags of `docker run`, so that Empire can attach to these tasks. (From https://github.com/aws/amazon-ecs-agent/compare/master...ejholmes:tty)
+2. [2-pids-limit](./patches/2-pids-limit): This patch will automatically remove the `nproc` ulimit, and replace it with the `--pids-limit` flag of Docker run (From https://github.com/aws/amazon-ecs-agent/compare/master...ejholmes:pids-limit)
 
 ## Updating to a new release
 

--- a/patches/2-pids-limit
+++ b/patches/2-pids-limit
@@ -1,0 +1,81 @@
+diff --git a/agent/engine/docker_task_engine.go b/agent/engine/docker_task_engine.go
+index 8330c89..1cdca1f 100644
+--- a/agent/engine/docker_task_engine.go
++++ b/agent/engine/docker_task_engine.go
+@@ -35,6 +35,7 @@ import (
+ 	utilsync "github.com/aws/amazon-ecs-agent/agent/utils/sync"
+ 	"github.com/aws/amazon-ecs-agent/agent/utils/ttime"
+ 	"github.com/cihub/seelog"
++	docker "github.com/fsouza/go-dockerclient"
+ )
+ 
+ const (
+@@ -577,6 +578,13 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
+ 		return DockerContainerMetadata{Error: api.NamedError(err)}
+ 	}
+ 
++	// docker run supports a --pids-limit flag, which replaces the nproc
++	// limit with a container aware version. In almost all circumstances,
++	// noproc should not be used, since it's global.
++	//
++	// See https://github.com/moby/moby/pull/18697
++	coercePidsLimit(hostConfig)
++
+ 	// Augment labels with some metadata from the agent. Explicitly do this last
+ 	// such that it will always override duplicates in the provided raw config
+ 	// data.
+@@ -859,3 +867,20 @@ func (engine *DockerTaskEngine) isParallelPullCompatible() bool {
+ 
+ 	return false
+ }
++
++func coercePidsLimit(config *docker.HostConfig) {
++	idx := -1
++	for i, l := range config.Ulimits {
++		if l.Name == "nproc" {
++			idx = i
++			break
++		}
++	}
++
++	if idx < 0 {
++		return
++	}
++
++	config.PidsLimit = config.Ulimits[idx].Soft
++	config.Ulimits = append(config.Ulimits[:idx], config.Ulimits[idx+1:]...)
++}
+diff --git a/agent/engine/docker_task_engine_test.go b/agent/engine/docker_task_engine_test.go
+index ec05b89..52f071d 100644
+--- a/agent/engine/docker_task_engine_test.go
++++ b/agent/engine/docker_task_engine_test.go
+@@ -1203,3 +1203,29 @@ func TestTaskWithCircularDependency(t *testing.T) {
+ 	_, ok = taskEngine.(*DockerTaskEngine).managedTasks[task.Arn]
+ 	assert.False(t, ok, "Task should not be added to task manager for processing")
+ }
++
++func TestCoercePidsLimit(t *testing.T) {
++	config := &docker.HostConfig{
++		Ulimits: []docker.ULimit{
++			{Name: "nproc", Soft: 90, Hard: 90},
++		},
++	}
++
++	coercePidsLimit(config)
++	assert.Equal(t, int64(90), config.PidsLimit)
++	assert.Equal(t, 0, len(config.Ulimits))
++	assert.Equal(t, []docker.ULimit{}, config.Ulimits)
++
++	nofile := docker.ULimit{Name: "nofile", Soft: 100, Hard: 100}
++	config = &docker.HostConfig{
++		Ulimits: []docker.ULimit{
++			nofile,
++			{Name: "nproc", Soft: 90, Hard: 90},
++		},
++	}
++
++	coercePidsLimit(config)
++	assert.Equal(t, int64(90), config.PidsLimit)
++	assert.Equal(t, 1, len(config.Ulimits))
++	assert.Equal(t, []docker.ULimit{nofile}, config.Ulimits)
++}


### PR DESCRIPTION
This adds a patch to our ECS agent that will remap the `nproc` ulimit to `--pids-limit` flag of Docker run.

I'm still waffling on whether or not this is the right layer to do this. I think doing it in the ECS agent might make the most sense because:

1. If you're configuring the Docker daemon to enable user namespace remapping, it's unlikely that you would ever actually want to set `nproc`, since it won't work the way you'd expect it to.
3. ECS doesn't explicitly support setting pid limits.
2. It's the easiest place to do it, and will get applied to all containers without any configuration.

With that said, the patch will take the `nproc` limit and remap it to `--pids-limit`, but the kernel that we use internally doesn't support pid limits, so this effectively just disables `nproc`, which is probably fine for now.