### PR TITLE
Upgrade TTY patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This builds an Amazon ECS Container Agent, with some patches applied for Remind'
 
 ## Patches
 
-1. [1-tty](./patches/1-tty): This patch provides a method to pass down the `-t` (allocate TTY) and `-i` (open stdin) flags of `docker run`, so that Empire can attach to these tasks. (From https://github.com/aws/amazon-ecs-agent/compare/master...ejholmes:tty)
+1. [1-tty](./patches/1-tty): This patch provides a method to pass down the `-t` (allocate TTY) and `-i` (open stdin) flags of `docker run`, so that Empire can attach to these tasks. (From https://github.com/aws/amazon-ecs-agent/compare/v1.18.0...ejholmes:tty)
 2. [2-pids-limit](./patches/2-pids-limit): This patch will automatically remove the `nproc` ulimit, and replace it with the `--pids-limit` flag of Docker run (From https://github.com/aws/amazon-ecs-agent/compare/master...ejholmes:pids-limit)
 2. [3-fix-netnsformat](./patches/3-fix-netnsformat): This patch fixes the ecscni module so that the ECS agent can configure network namespaces, when not running within a Docker container. (From https://github.com/aws/amazon-ecs-agent/compare/master...ejholmes:fix-netnsformat)
 

--- a/patches/1-tty
+++ b/patches/1-tty
@@ -1,34 +1,42 @@
 diff --git a/agent/engine/docker_task_engine.go b/agent/engine/docker_task_engine.go
-index 25866f4..af8470e 100644
+index 492126b..e35e4e4 100644
 --- a/agent/engine/docker_task_engine.go
 +++ b/agent/engine/docker_task_engine.go
-@@ -707,6 +707,16 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
- 		return DockerContainerMetadata{Error: api.NamedError(err)}
+@@ -843,6 +843,22 @@ func (engine *DockerTaskEngine) createContainer(task *api.Task, container *api.C
+ 		return dockerapi.DockerContainerMetadata{Error: apierrors.NamedError(err)}
  	}
  
 +	if v, ok := config.Labels["docker.config.Tty"]; ok {
 +		config.Tty, _ = strconv.ParseBool(v)
 +		delete(config.Labels, "docker.config.Tty")
 +	}
++	if v, ok := container.Environment["ECS_DOCKER_CONFIG_TTY"]; ok {
++		config.Tty, _ = strconv.ParseBool(v)
++	}
 +
 +	if v, ok := config.Labels["docker.config.OpenStdin"]; ok {
 +		config.OpenStdin, _ = strconv.ParseBool(v)
 +		delete(config.Labels, "docker.config.OpenStdin")
++	}
++	if v, ok := container.Environment["ECS_DOCKER_CONFIG_OPEN_STDIN"]; ok {
++		config.OpenStdin, _ = strconv.ParseBool(v)
 +	}
 +
  	// Augment labels with some metadata from the agent. Explicitly do this last
  	// such that it will always override duplicates in the provided raw config
  	// data.
 diff --git a/agent/engine/docker_task_engine_test.go b/agent/engine/docker_task_engine_test.go
-index e8362f5..c3ead7c 100644
+index adc8fc7..0a581e5 100644
 --- a/agent/engine/docker_task_engine_test.go
 +++ b/agent/engine/docker_task_engine_test.go
-@@ -1242,6 +1242,41 @@ func TestCreateContainerMergesLabels(t *testing.T) {
+@@ -756,6 +756,81 @@ func TestCreateContainerMergesLabels(t *testing.T) {
  	taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
  }
  
 +func TestCreateContainerAllowsExtraDockerConfigInLabels(t *testing.T) {
-+	ctrl, client, _, taskEngine, _, _, _ := mocks(t, &defaultConfig)
++	ctx, cancel := context.WithCancel(context.TODO())
++	defer cancel()
++	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
 +	defer ctrl.Finish()
 +
 +	testTask := &api.Task{
@@ -58,10 +66,48 @@ index e8362f5..c3ead7c 100644
 +		"com.amazonaws.ecs.cluster":                 "",
 +	}
 +	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
-+	client.EXPECT().CreateContainer(expectedConfig, gomock.Any(), gomock.Any(), gomock.Any())
++	client.EXPECT().CreateContainer(gomock.Any(), expectedConfig, gomock.Any(), gomock.Any(), gomock.Any())
++	taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
++}
++
++func TestCreateContainerAllowsExtraDockerConfigInEnvironment(t *testing.T) {
++	ctx, cancel := context.WithCancel(context.TODO())
++	defer cancel()
++	ctrl, client, _, taskEngine, _, _, _ := mocks(t, ctx, &defaultConfig)
++	defer ctrl.Finish()
++
++	testTask := &api.Task{
++		Arn:     "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
++		Family:  "myFamily",
++		Version: "1",
++		Containers: []*api.Container{
++			&api.Container{
++				Name: "c1",
++				Environment: map[string]string{
++					"ECS_DOCKER_CONFIG_TTY":        "true",
++					"ECS_DOCKER_CONFIG_OPEN_STDIN": "true",
++				},
++			},
++		},
++	}
++	expectedConfig, err := testTask.DockerConfig(testTask.Containers[0], defaultDockerClientAPIVersion)
++	if err != nil {
++		t.Fatal(err)
++	}
++	expectedConfig.Tty = true
++	expectedConfig.OpenStdin = true
++	expectedConfig.Labels = map[string]string{
++		"com.amazonaws.ecs.task-arn":                "arn:aws:ecs:us-east-1:012345678910:task/c09f0188-7f87-4b0f-bfc3-16296622b6fe",
++		"com.amazonaws.ecs.container-name":          "c1",
++		"com.amazonaws.ecs.task-definition-family":  "myFamily",
++		"com.amazonaws.ecs.task-definition-version": "1",
++		"com.amazonaws.ecs.cluster":                 "",
++	}
++	client.EXPECT().APIVersion().Return(defaultDockerClientAPIVersion, nil).AnyTimes()
++	client.EXPECT().CreateContainer(gomock.Any(), expectedConfig, gomock.Any(), gomock.Any(), gomock.Any())
 +	taskEngine.(*DockerTaskEngine).createContainer(testTask, testTask.Containers[0])
 +}
 +
  // TestTaskTransitionWhenStopContainerTimesout tests that task transitions to stopped
- // only when terminal events are recieved from docker event stream when
+ // only when terminal events are received from docker event stream when
  // StopContainer times out


### PR DESCRIPTION
This upgrades the TTY patch that we apply, to also allow the `--tty` and `--open-stdin` flags to be set through environment variables. In some cases, this works better than using docker labels, since environment variables can be overriden in the [ecs.RunTask](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_RunTask.html#ECS-RunTask-request-overrides) API, whereas docker labels cannot.