### PR TITLE
Update to v1.51.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build test pull GO_VERSION
 
-REVISION=v1.50.2
+REVISION=v1.51.0
 BUILD_IMAGE=remind101/amazon-ecs-agent:${REVISION}
 OFFICIAL_IMAGE=amazon/amazon-ecs-agent:${REVISION}
 


### PR DESCRIPTION
To be merged shortly after https://github.com/remind101/amazon-ecs-agent/pull/5

The https://github.com/remind101/amazon-ecs-agent/releases/tag/v1.50.2 pre-release already includes this so we'll want to merge both.